### PR TITLE
Increase resource cost

### DIFF
--- a/assets/attrib/instances/ebps/races/abbasid/buildings/building_defense_keep_control_abb.xml
+++ b/assets/attrib/instances/ebps/races/abbasid/buildings/building_defense_keep_control_abb.xml
@@ -277,11 +277,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="800" />
+					<float name="stone" value="1200" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="140" />
+				<float name="time_seconds" value="210" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>
@@ -2212,7 +2212,7 @@
 			<float name="number_of_standard_slots" value="-1" />
 			<list name="standard_upgrades">
 				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_springald" />
-				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" />
+				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
 				<instance_reference name="upgrade" value="upgrade\races\common\research\economy\upgrade_tech_university_murder_holes_4" />
 			</list>
 			<int name="max_queue_size_override" value="-1" />

--- a/assets/attrib/instances/ebps/races/abbasid/buildings/building_defense_palisade_abb.xml
+++ b/assets/attrib/instances/ebps/races/abbasid/buildings/building_defense_palisade_abb.xml
@@ -280,7 +280,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/abbasid/buildings/building_defense_tower_abb.xml
+++ b/assets/attrib/instances/ebps/races/abbasid/buildings/building_defense_tower_abb.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="90" />
+				<float name="time_seconds" value="120" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/ebps/races/chinese/buildings/building_defense_keep_chi/building_defense_keep_chi.xml
+++ b/assets/attrib/instances/ebps/races/chinese/buildings/building_defense_keep_chi/building_defense_keep_chi.xml
@@ -276,11 +276,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="800" />
+					<float name="stone" value="1200" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="210" overrideParent="True" />
+				<float name="time_seconds" value="240" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>
@@ -2211,7 +2211,7 @@
 			<float name="number_of_standard_slots" value="-1" />
 			<list name="standard_upgrades" overrideParent="True">
 				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_springald" />
-				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" />
+				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
 				<instance_reference name="upgrade" value="upgrade\races\chinese\research\upgrade_wall_repair_chi" />
 				<instance_reference name="upgrade" value="upgrade\races\common\research\economy\upgrade_tech_university_murder_holes_4" />
 			</list>

--- a/assets/attrib/instances/ebps/races/chinese/buildings/building_defense_wall_chi/building_defense_palisade_bastion_chi.xml
+++ b/assets/attrib/instances/ebps/races/chinese/buildings/building_defense_wall_chi/building_defense_palisade_bastion_chi.xml
@@ -278,7 +278,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/chinese/buildings/building_defense_wall_chi/building_defense_palisade_chi.xml
+++ b/assets/attrib/instances/ebps/races/chinese/buildings/building_defense_wall_chi/building_defense_palisade_chi.xml
@@ -280,7 +280,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/chinese/buildings/building_defense_wall_chi/building_defense_tower_chi.xml
+++ b/assets/attrib/instances/ebps/races/chinese/buildings/building_defense_wall_chi/building_defense_tower_chi.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="120" overrideParent="True" />
+				<float name="time_seconds" value="180" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/ebps/races/core/buildings/building_defense_keep.xml
+++ b/assets/attrib/instances/ebps/races/core/buildings/building_defense_keep.xml
@@ -275,11 +275,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="800" />
+					<float name="stone" value="1200" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="140" />
+				<float name="time_seconds" value="210" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>
@@ -2200,7 +2200,7 @@
 			<float name="number_of_standard_slots" value="-1" />
 			<list name="standard_upgrades">
 				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_springald" />
-				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" />
+				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
 				<instance_reference name="upgrade" value="upgrade\races\common\research\economy\upgrade_tech_university_murder_holes_4" />
 			</list>
 			<int name="max_queue_size_override" value="-1" />

--- a/assets/attrib/instances/ebps/races/core/buildings/building_defense_tower.xml
+++ b/assets/attrib/instances/ebps/races/core/buildings/building_defense_tower.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="90" />
+				<float name="time_seconds" value="120" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/ebps/races/english/buildings/building_defense_keep_eng/building_defense_keep_eng.xml
+++ b/assets/attrib/instances/ebps/races/english/buildings/building_defense_keep_eng/building_defense_keep_eng.xml
@@ -278,11 +278,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="800" />
+					<float name="stone" value="1200" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="140" />
+				<float name="time_seconds" value="210" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>
@@ -2824,7 +2824,7 @@
 			<float name="number_of_standard_slots" value="-1" />
 			<list name="standard_upgrades" overrideParent="True">
 				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_springald" />
-				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" />
+				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
 				<instance_reference name="upgrade" value="upgrade\races\english\research\upgrade_network_of_citadels_eng" />
 				<instance_reference name="upgrade" value="upgrade\races\common\research\economy\upgrade_tech_university_murder_holes_4" />
 			</list>

--- a/assets/attrib/instances/ebps/races/english/buildings/building_defense_wall_eng/building_defense_palisade_bastion_eng.xml
+++ b/assets/attrib/instances/ebps/races/english/buildings/building_defense_wall_eng/building_defense_palisade_bastion_eng.xml
@@ -278,7 +278,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/english/buildings/building_defense_wall_eng/building_defense_palisade_eng.xml
+++ b/assets/attrib/instances/ebps/races/english/buildings/building_defense_wall_eng/building_defense_palisade_eng.xml
@@ -280,7 +280,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/english/buildings/building_defense_wall_eng/building_defense_tower_eng.xml
+++ b/assets/attrib/instances/ebps/races/english/buildings/building_defense_wall_eng/building_defense_tower_eng.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="90" />
+				<float name="time_seconds" value="120" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/ebps/races/french/buildings/building_defense_keep_fre/building_defense_keep_fre.xml
+++ b/assets/attrib/instances/ebps/races/french/buildings/building_defense_keep_fre/building_defense_keep_fre.xml
@@ -276,11 +276,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="800" />
+					<float name="stone" value="1200" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="140" />
+				<float name="time_seconds" value="210" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>
@@ -2207,7 +2207,7 @@
 			<float name="number_of_standard_slots" value="-1" />
 			<list name="standard_upgrades" overrideParent="True">
 				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_springald" />
-				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" />
+				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
 				<instance_reference name="upgrade" value="upgrade\races\common\research\economy\upgrade_tech_university_murder_holes_4" />
 				<instance_reference name="upgrade" value="upgrade\races\french\research\upgrade_enlistment_incentives_fre" />
 			</list>

--- a/assets/attrib/instances/ebps/races/french/buildings/building_defense_wall_fre/building_defense_palisade_bastion_fre.xml
+++ b/assets/attrib/instances/ebps/races/french/buildings/building_defense_wall_fre/building_defense_palisade_bastion_fre.xml
@@ -278,7 +278,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/french/buildings/building_defense_wall_fre/building_defense_palisade_fre.xml
+++ b/assets/attrib/instances/ebps/races/french/buildings/building_defense_wall_fre/building_defense_palisade_fre.xml
@@ -280,7 +280,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/french/buildings/building_defense_wall_fre/building_defense_tower_fre.xml
+++ b/assets/attrib/instances/ebps/races/french/buildings/building_defense_wall_fre/building_defense_tower_fre.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="90" />
+				<float name="time_seconds" value="120" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/ebps/races/hre/buildings/building_defense_keep_hre/building_defense_keep_hre.xml
+++ b/assets/attrib/instances/ebps/races/hre/buildings/building_defense_keep_hre/building_defense_keep_hre.xml
@@ -277,11 +277,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="800" />
+					<float name="stone" value="1200" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="140" />
+				<float name="time_seconds" value="210" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>
@@ -2216,7 +2216,7 @@
 			<float name="number_of_standard_slots" value="-1" />
 			<list name="standard_upgrades" overrideParent="True">
 				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_springald" />
-				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" />
+				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
 				<instance_reference name="upgrade" value="upgrade\races\hre\research\upgrade_building_fire_armor_hre" />
 				<instance_reference name="upgrade" value="upgrade\races\hre\research\upgrade_reinforced_defenses_hre" />
 				<instance_reference name="upgrade" value="upgrade\races\common\research\economy\upgrade_tech_university_murder_holes_4" />

--- a/assets/attrib/instances/ebps/races/hre/buildings/building_defense_wall_hre/building_defense_palisade_bastion_hre.xml
+++ b/assets/attrib/instances/ebps/races/hre/buildings/building_defense_wall_hre/building_defense_palisade_bastion_hre.xml
@@ -278,7 +278,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/hre/buildings/building_defense_wall_hre/building_defense_palisade_gate_hre.xml
+++ b/assets/attrib/instances/ebps/races/hre/buildings/building_defense_wall_hre/building_defense_palisade_gate_hre.xml
@@ -273,7 +273,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="25" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/hre/buildings/building_defense_wall_hre/building_defense_tower_hre.xml
+++ b/assets/attrib/instances/ebps/races/hre/buildings/building_defense_wall_hre/building_defense_tower_hre.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="90" />
+				<float name="time_seconds" value="120" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/ebps/races/mongol/buildings/building_defense_outpost_mon.xml
+++ b/assets/attrib/instances/ebps/races/mongol/buildings/building_defense_outpost_mon.xml
@@ -316,7 +316,7 @@
 			<list name="standard_upgrades" overrideParent="True">
 				<instance_reference name="upgrade" value="upgrade\races\mongol\research\upgrade_outpost_arrowslits_mon" overrideParent="True" />
 				<instance_reference name="upgrade" value="upgrade\races\mongol\research\upgrade_outpost_springald_mon" overrideParent="True" />
-				<instance_reference name="upgrade" value="upgrade\races\mongol\research\upgrade_outpost_cannon_mon" overrideParent="True" />
+				<instance_reference name="upgrade" value="upgrade\races\mongol\research\upgrade_outpost_cannon_mon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" overrideParent="True" />
 				<instance_reference name="upgrade" value="upgrade\races\mongol\research\unique\upgrade_ortoo_all_units_mon" />
 			</list>
 			<int name="max_queue_size_override" value="-1" />

--- a/assets/attrib/instances/ebps/races/rus/buildings/building_defense_keep_rus/building_defense_keep_control_rus.xml
+++ b/assets/attrib/instances/ebps/races/rus/buildings/building_defense_keep_rus/building_defense_keep_control_rus.xml
@@ -276,11 +276,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="800" />
+					<float name="stone" value="1200" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="140" />
+				<float name="time_seconds" value="210" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>
@@ -2177,7 +2177,7 @@
 			<float name="number_of_standard_slots" value="-1" />
 			<list name="standard_upgrades" overrideParent="True">
 				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_springald" />
-				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" />
+				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
 				<instance_reference name="upgrade" value="upgrade\races\common\research\economy\upgrade_tech_university_murder_holes_4" />
 			</list>
 			<int name="max_queue_size_override" value="-1" />

--- a/assets/attrib/instances/ebps/races/rus/buildings/building_defense_wall_rus/building_defense_palisade_bastion_rus.xml
+++ b/assets/attrib/instances/ebps/races/rus/buildings/building_defense_wall_rus/building_defense_palisade_bastion_rus.xml
@@ -278,7 +278,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/rus/buildings/building_defense_wall_rus/building_defense_tower_rus.xml
+++ b/assets/attrib/instances/ebps/races/rus/buildings/building_defense_wall_rus/building_defense_tower_rus.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="90" />
+				<float name="time_seconds" value="120" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_keep_sul/building_defense_keep_control_sul.xml
+++ b/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_keep_sul/building_defense_keep_control_sul.xml
@@ -276,11 +276,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="800" />
+					<float name="stone" value="1200" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="140" />
+				<float name="time_seconds" value="210" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>
@@ -2261,7 +2261,7 @@
 			<float name="number_of_standard_slots" value="-1" />
 			<list name="standard_upgrades" overrideParent="True">
 				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_springald" />
-				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" />
+				<instance_reference name="upgrade" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
 				<instance_reference name="upgrade" value="upgrade\races\sultanate\research\landmark\upgrade_age2_keep_town_center_sul" />
 				<instance_reference name="upgrade" value="upgrade\races\sultanate\research\upgrade_landmark_keep_defense_sul" />
 				<instance_reference name="upgrade" value="upgrade\races\sultanate\research\economy\upgrade_tech_university_murder_holes_4_sul" />

--- a/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_wall_sul/building_defense_palisade_bastion_sul.xml
+++ b/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_wall_sul/building_defense_palisade_bastion_sul.xml
@@ -278,7 +278,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="5" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_wall_sul/building_defense_palisade_gate_sul.xml
+++ b/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_wall_sul/building_defense_palisade_gate_sul.xml
@@ -273,7 +273,7 @@
 					<float name="popcap" value="0" />
 					<float name="command" value="0" />
 					<float name="food" value="0" />
-					<float name="wood" value="25" />
+					<float name="wood" value="8" overrideParent="True" />
 					<float name="stone" value="0" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />

--- a/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_wall_sul/building_defense_tower_infantry_sul.xml
+++ b/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_wall_sul/building_defense_tower_infantry_sul.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="90" />
+				<float name="time_seconds" value="120" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_wall_sul/building_defense_tower_sul.xml
+++ b/assets/attrib/instances/ebps/races/sultanate/buildings/building_defense_wall_sul/building_defense_tower_sul.xml
@@ -28,11 +28,11 @@
 					<float name="command" value="0" />
 					<float name="food" value="0" />
 					<float name="wood" value="0" />
-					<float name="stone" value="300" />
+					<float name="stone" value="600" overrideParent="True" />
 					<float name="gold" value="0" />
 					<float name="militia_hre" value="0" />
 				</enum_table>
-				<float name="time_seconds" value="90" />
+				<float name="time_seconds" value="120" overrideParent="True" />
 				<int name="time_turns" value="0" />
 			</group>
 		</template_reference>

--- a/assets/attrib/instances/upgrade/races/chinese/research/upgrade_keep_handcannonslits_chi.xml
+++ b/assets/attrib/instances/upgrade/races/chinese/research/upgrade_keep_handcannonslits_chi.xml
@@ -1,0 +1,168 @@
+<instance description="Adds Handcannons to the castle" template="upgrade">
+	<group name="upgrade_bag">
+		<bool name="enable_in_hold" value="False" />
+		<float name="global_max_limit" value="0" />
+		<bool name="has_speech_code" value="False" />
+		<float name="local_max_limit" value="1" />
+		<enum name="owner_type" value="self" />
+		<group name="time_cost">
+			<enum_table name="cost">
+				<float name="action" value="0" />
+				<float name="command" value="0" />
+				<float name="popcap" value="0" />
+				<float name="food" value="0" />
+				<float name="wood" value="0" />
+				<float name="stone" value="75" />
+				<float name="gold" value="50" />
+				<float name="militia_hre" value="0" />
+			</enum_table>
+			<float name="time_seconds" value="40" />
+		</group>
+		<bool name="ui_event_cue" value="True" />
+		<enum name="ui_production_group" value="command_panel" />
+		<group name="ui_info">
+			<locstring name="extra_text" value="11143361" />
+			<locstring name="help_text" value="11155647" />
+			<string name="hotkey_name" value="q" />
+			<file name="icon_name" value="races\common\upgrades\handcannon_slits" />
+			<bool name="reveal_for_decryption" value="False" />
+			<locstring name="screen_name" value="11155650" />
+			<locstring name="brief_text" value="0" />
+			<locstring name="screen_name_short" value="0" />
+			<string name="debug_text" value="" />
+			<string name="tooltip_data_template" value="BuildingUpgradeDataTemplate" />
+			<enum name="ui_combine_type" value="intersection" />
+			<template_reference name="brief_text_formatter" value="">
+			</template_reference>
+			<template_reference name="extra_text_formatter" value="">
+			</template_reference>
+			<template_reference name="help_text_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_short_formatter" value="">
+			</template_reference>
+			<string name="sound" value="sfx_ui_produce_upgrade_building_click" />
+			<string name="sound_alternative" value="" />
+			<int name="global_unit_control_row" value="1" />
+		</group>
+		<list name="requirements">
+			<template_reference name="required" value="requirements\required_player_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="True" />
+				<int name="max_completed" value="100" />
+				<int name="min_completed" value="1" />
+				<instance_reference name="upgrade_name" value="upgrade\dev\ages\feudal_age" />
+				<bool name="include_queued" value="False" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\chinese\research\upgrade_keep_handcannonslits_chi" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\chinese\research\upgrade_keep_handcannonslits_chi" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+		</list>
+		<file name="ui_kicker_icon_name" value="" />
+		<locstring name="ui_squad_name_override" value="0" />
+		<locstring name="ui_squad_help_text_override" value="0" />
+		<locstring name="ui_squad_extra_text_override" value="0" />
+		<list name="ui_preview">
+		</list>
+		<string name="speech_code" value="" />
+		<file name="ui_squad_portrait_icon_override" value="" />
+		<group name="ui_position">
+			<int name="ui_position_row" value="1" />
+			<int name="ui_position_column" value="1" />
+		</group>
+		<float name="min_music_intensity" value="0" />
+		<group name="state_tree_references">
+			<template_reference name="on_begin_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="upgrade_keep\upgrade_keep_handcannonslits_chi" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_cancel_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_entity_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_squad_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+		</group>
+		<list name="upgrade_type">
+			<enum name="upgrade_type" value="military_upgrade" />
+		</list>
+		<string name="requirements_openingbranch" value="" />
+		<instance_reference name="ui_menu" value="" />
+		<bool name="is_progress_permanent" value="False" />
+		<group name="ui_codex_info">
+			<int name="priority" value="0" />
+			<bool name="exclusive" value="False" />
+			<group name="ui_position">
+				<int name="ui_position_column" value="-1" />
+				<int name="ui_position_row" value="-1" />
+			</group>
+		</group>
+		<group name="filter_conditions">
+			<state_tree_node name="apply_to_filter_condition_statetree_ref" value="" />
+			<enum name="apply_to_target_type" value="entity" />
+			<list name="apply_to_unit_classes">
+			</list>
+			<enum name="apply_to_application_type" value="current_and_future_units" />
+			<enum name="apply_to_future_units" value="current_and_future_units" />
+		</group>
+		<enum_table name="squad_cost">
+			<float name="action" value="0" />
+			<float name="command" value="0" />
+			<float name="popcap" value="0" />
+			<float name="food" value="0" />
+			<float name="wood" value="0" />
+			<float name="stone" value="0" />
+			<float name="gold" value="0" />
+			<float name="militia_hre" value="0" />
+		</enum_table>
+		<list name="float_properties">
+		</list>
+		<list name="int_properties">
+		</list>
+		<enum name="ui_group_cast_type" value="single" />
+	</group>
+	<uniqueid name="pbgid" value="173753" />
+	<instance_reference name="parent_pbg" value="" />
+</instance>

--- a/assets/attrib/instances/upgrade/races/chinese/research/upgrade_tower_handcannonslits_chi.xml
+++ b/assets/attrib/instances/upgrade/races/chinese/research/upgrade_tower_handcannonslits_chi.xml
@@ -1,0 +1,224 @@
+<instance description="Adds handcannonslitto the tower" template="upgrade">
+	<group name="upgrade_bag">
+		<bool name="enable_in_hold" value="False" />
+		<float name="global_max_limit" value="0" />
+		<bool name="has_speech_code" value="False" />
+		<float name="local_max_limit" value="1" />
+		<enum name="owner_type" value="self" />
+		<group name="time_cost">
+			<enum_table name="cost">
+				<float name="action" value="0" />
+				<float name="command" value="0" />
+				<float name="popcap" value="0" />
+				<float name="food" value="0" />
+				<float name="wood" value="0" />
+				<float name="stone" value="75" />
+				<float name="gold" value="50" />
+				<float name="militia_hre" value="0" />
+			</enum_table>
+			<float name="time_seconds" value="40" />
+		</group>
+		<bool name="ui_event_cue" value="True" />
+		<enum name="ui_production_group" value="command_panel" />
+		<group name="ui_info">
+			<locstring name="extra_text" value="11143361" />
+			<locstring name="help_text" value="11155647" />
+			<string name="hotkey_name" value="q" />
+			<file name="icon_name" value="races\common\upgrades\handcannon_slits" />
+			<bool name="reveal_for_decryption" value="False" />
+			<locstring name="screen_name" value="11155650" />
+			<locstring name="brief_text" value="0" />
+			<locstring name="screen_name_short" value="0" />
+			<string name="debug_text" value="" />
+			<string name="tooltip_data_template" value="BuildingUpgradeDataTemplate" />
+			<enum name="ui_combine_type" value="intersection" />
+			<template_reference name="brief_text_formatter" value="">
+			</template_reference>
+			<template_reference name="extra_text_formatter" value="">
+			</template_reference>
+			<template_reference name="help_text_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_short_formatter" value="">
+			</template_reference>
+			<string name="sound" value="sfx_ui_produce_upgrade_building_click" />
+			<string name="sound_alternative" value="" />
+			<int name="global_unit_control_row" value="1" />
+		</group>
+		<list name="requirements">
+			<template_reference name="required" value="requirements\required_player_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="True" />
+				<int name="max_completed" value="100" />
+				<int name="min_completed" value="1" />
+				<instance_reference name="upgrade_name" value="upgrade\dev\ages\feudal_age" />
+				<bool name="include_queued" value="False" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\chinese\research\upgrade_tower_handcannonslits_chi" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\chinese\research\upgrade_tower_handcannonslits_chi" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_springald" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_springald" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_cannon" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_cannon" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+		</list>
+		<file name="ui_kicker_icon_name" value="" />
+		<locstring name="ui_squad_name_override" value="0" />
+		<locstring name="ui_squad_help_text_override" value="0" />
+		<locstring name="ui_squad_extra_text_override" value="0" />
+		<list name="ui_preview">
+		</list>
+		<string name="speech_code" value="" />
+		<file name="ui_squad_portrait_icon_override" value="" />
+		<group name="ui_position">
+			<int name="ui_position_row" value="1" />
+			<int name="ui_position_column" value="1" />
+		</group>
+		<float name="min_music_intensity" value="0" />
+		<group name="state_tree_references">
+			<template_reference name="on_begin_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="upgrade_tower\upgrade_tower_handcannonslits_chi" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_cancel_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_entity_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_squad_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+		</group>
+		<list name="upgrade_type">
+			<enum name="upgrade_type" value="military_upgrade" />
+		</list>
+		<string name="requirements_openingbranch" value="" />
+		<instance_reference name="ui_menu" value="" />
+		<bool name="is_progress_permanent" value="False" />
+		<group name="ui_codex_info">
+			<int name="priority" value="0" />
+			<bool name="exclusive" value="False" />
+			<group name="ui_position">
+				<int name="ui_position_column" value="-1" />
+				<int name="ui_position_row" value="-1" />
+			</group>
+		</group>
+		<group name="filter_conditions">
+			<state_tree_node name="apply_to_filter_condition_statetree_ref" value="" />
+			<enum name="apply_to_target_type" value="entity" />
+			<list name="apply_to_unit_classes">
+			</list>
+			<enum name="apply_to_application_type" value="current_and_future_units" />
+			<enum name="apply_to_future_units" value="current_and_future_units" />
+		</group>
+		<enum_table name="squad_cost">
+			<float name="action" value="0" />
+			<float name="command" value="0" />
+			<float name="popcap" value="0" />
+			<float name="food" value="0" />
+			<float name="wood" value="0" />
+			<float name="stone" value="0" />
+			<float name="gold" value="0" />
+			<float name="militia_hre" value="0" />
+		</enum_table>
+		<list name="float_properties">
+		</list>
+		<list name="int_properties">
+		</list>
+		<enum name="ui_group_cast_type" value="single" />
+	</group>
+	<uniqueid name="pbgid" value="173762" />
+	<instance_reference name="parent_pbg" value="" />
+</instance>

--- a/assets/attrib/instances/upgrade/races/common/research/upgrade_keep_cannon.xml
+++ b/assets/attrib/instances/upgrade/races/common/research/upgrade_keep_cannon.xml
@@ -1,0 +1,168 @@
+<instance description="Adds cannon to the keep" template="upgrade">
+	<group name="upgrade_bag">
+		<bool name="enable_in_hold" value="False" />
+		<float name="global_max_limit" value="0" />
+		<bool name="has_speech_code" value="False" />
+		<float name="local_max_limit" value="1" />
+		<enum name="owner_type" value="self" />
+		<group name="time_cost">
+			<enum_table name="cost">
+				<float name="action" value="0" />
+				<float name="command" value="0" />
+				<float name="popcap" value="0" />
+				<float name="food" value="0" />
+				<float name="wood" value="0" />
+				<float name="stone" value="450" />
+				<float name="gold" value="150" />
+				<float name="militia_hre" value="0" />
+			</enum_table>
+			<float name="time_seconds" value="70" />
+		</group>
+		<bool name="ui_event_cue" value="True" />
+		<enum name="ui_production_group" value="command_panel" />
+		<group name="ui_info">
+			<locstring name="extra_text" value="11146084" />
+			<locstring name="help_text" value="11146083" />
+			<string name="hotkey_name" value="e" />
+			<file name="icon_name" value="races\common\upgrades\cannon" />
+			<bool name="reveal_for_decryption" value="False" />
+			<locstring name="screen_name" value="11146085" />
+			<locstring name="brief_text" value="0" />
+			<locstring name="screen_name_short" value="0" />
+			<string name="debug_text" value="" />
+			<string name="tooltip_data_template" value="BuildingUpgradeDataTemplate" />
+			<enum name="ui_combine_type" value="intersection" />
+			<template_reference name="brief_text_formatter" value="">
+			</template_reference>
+			<template_reference name="extra_text_formatter" value="">
+			</template_reference>
+			<template_reference name="help_text_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_short_formatter" value="">
+			</template_reference>
+			<string name="sound" value="sfx_ui_produce_upgrade_building_click" />
+			<string name="sound_alternative" value="" />
+			<int name="global_unit_control_row" value="1" />
+		</group>
+		<list name="requirements">
+			<template_reference name="required" value="requirements\required_player_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="True" />
+				<int name="max_completed" value="100" />
+				<int name="min_completed" value="1" />
+				<instance_reference name="upgrade_name" value="upgrade\dev\ages\imperial_age" />
+				<bool name="include_queued" value="False" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_keep_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+		</list>
+		<file name="ui_kicker_icon_name" value="" />
+		<locstring name="ui_squad_name_override" value="0" />
+		<locstring name="ui_squad_help_text_override" value="0" />
+		<locstring name="ui_squad_extra_text_override" value="0" />
+		<list name="ui_preview">
+		</list>
+		<string name="speech_code" value="" />
+		<file name="ui_squad_portrait_icon_override" value="" />
+		<group name="ui_position">
+			<int name="ui_position_row" value="1" />
+			<int name="ui_position_column" value="2" />
+		</group>
+		<float name="min_music_intensity" value="0" />
+		<group name="state_tree_references">
+			<template_reference name="on_begin_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="upgrade_keep\upgrade_keep_cannon" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_cancel_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_entity_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_squad_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+		</group>
+		<list name="upgrade_type">
+			<enum name="upgrade_type" value="military_upgrade" />
+		</list>
+		<string name="requirements_openingbranch" value="" />
+		<instance_reference name="ui_menu" value="" />
+		<bool name="is_progress_permanent" value="False" />
+		<group name="ui_codex_info">
+			<int name="priority" value="7000" />
+			<bool name="exclusive" value="False" />
+			<group name="ui_position">
+				<int name="ui_position_column" value="-1" />
+				<int name="ui_position_row" value="-1" />
+			</group>
+		</group>
+		<group name="filter_conditions">
+			<state_tree_node name="apply_to_filter_condition_statetree_ref" value="" />
+			<enum name="apply_to_target_type" value="entity" />
+			<list name="apply_to_unit_classes">
+			</list>
+			<enum name="apply_to_application_type" value="current_and_future_units" />
+			<enum name="apply_to_future_units" value="current_and_future_units" />
+		</group>
+		<enum_table name="squad_cost">
+			<float name="action" value="0" />
+			<float name="command" value="0" />
+			<float name="popcap" value="0" />
+			<float name="food" value="0" />
+			<float name="wood" value="0" />
+			<float name="stone" value="0" />
+			<float name="gold" value="0" />
+			<float name="militia_hre" value="0" />
+		</enum_table>
+		<list name="float_properties">
+		</list>
+		<list name="int_properties">
+		</list>
+		<enum name="ui_group_cast_type" value="single" />
+	</group>
+	<uniqueid name="pbgid" value="185626" />
+	<instance_reference name="parent_pbg" value="" />
+</instance>

--- a/assets/attrib/instances/upgrade/races/common/research/upgrade_tower_cannon.xml
+++ b/assets/attrib/instances/upgrade/races/common/research/upgrade_tower_cannon.xml
@@ -1,0 +1,224 @@
+<instance description="Adds cannon to the tower" template="upgrade">
+	<group name="upgrade_bag">
+		<bool name="enable_in_hold" value="False" />
+		<float name="global_max_limit" value="0" />
+		<bool name="has_speech_code" value="False" />
+		<float name="local_max_limit" value="1" />
+		<enum name="owner_type" value="self" />
+		<group name="time_cost">
+			<enum_table name="cost">
+				<float name="action" value="0" />
+				<float name="command" value="0" />
+				<float name="popcap" value="0" />
+				<float name="food" value="0" />
+				<float name="wood" value="0" />
+				<float name="stone" value="450" />
+				<float name="gold" value="150" />
+				<float name="militia_hre" value="0" />
+			</enum_table>
+			<float name="time_seconds" value="70" />
+		</group>
+		<bool name="ui_event_cue" value="True" />
+		<enum name="ui_production_group" value="command_panel" />
+		<group name="ui_info">
+			<locstring name="extra_text" value="11146084" />
+			<locstring name="help_text" value="11205518" />
+			<string name="hotkey_name" value="e" />
+			<file name="icon_name" value="races\common\upgrades\cannon" />
+			<bool name="reveal_for_decryption" value="False" />
+			<locstring name="screen_name" value="11146085" />
+			<locstring name="brief_text" value="0" />
+			<locstring name="screen_name_short" value="0" />
+			<string name="debug_text" value="" />
+			<string name="tooltip_data_template" value="BuildingUpgradeDataTemplate" />
+			<enum name="ui_combine_type" value="intersection" />
+			<template_reference name="brief_text_formatter" value="">
+			</template_reference>
+			<template_reference name="extra_text_formatter" value="">
+			</template_reference>
+			<template_reference name="help_text_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_short_formatter" value="">
+			</template_reference>
+			<string name="sound" value="sfx_ui_produce_upgrade_building_click" />
+			<string name="sound_alternative" value="" />
+			<int name="global_unit_control_row" value="1" />
+		</group>
+		<list name="requirements">
+			<template_reference name="required" value="requirements\required_player_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="True" />
+				<int name="max_completed" value="100" />
+				<int name="min_completed" value="1" />
+				<instance_reference name="upgrade_name" value="upgrade\dev\ages\imperial_age" />
+				<bool name="include_queued" value="False" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_arrowslits" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_arrowslits" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_springald" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_springald" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\common\research\upgrade_tower_cannon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+		</list>
+		<file name="ui_kicker_icon_name" value="" />
+		<locstring name="ui_squad_name_override" value="0" />
+		<locstring name="ui_squad_help_text_override" value="0" />
+		<locstring name="ui_squad_extra_text_override" value="0" />
+		<list name="ui_preview">
+		</list>
+		<string name="speech_code" value="" />
+		<file name="ui_squad_portrait_icon_override" value="" />
+		<group name="ui_position">
+			<int name="ui_position_row" value="1" />
+			<int name="ui_position_column" value="3" />
+		</group>
+		<float name="min_music_intensity" value="0" />
+		<group name="state_tree_references">
+			<template_reference name="on_begin_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="upgrade_tower\upgrade_tower_cannon" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_cancel_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_entity_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_squad_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+		</group>
+		<list name="upgrade_type">
+			<enum name="upgrade_type" value="military_upgrade" />
+		</list>
+		<string name="requirements_openingbranch" value="" />
+		<instance_reference name="ui_menu" value="" />
+		<bool name="is_progress_permanent" value="False" />
+		<group name="ui_codex_info">
+			<int name="priority" value="7000" />
+			<bool name="exclusive" value="False" />
+			<group name="ui_position">
+				<int name="ui_position_column" value="-1" />
+				<int name="ui_position_row" value="-1" />
+			</group>
+		</group>
+		<group name="filter_conditions">
+			<state_tree_node name="apply_to_filter_condition_statetree_ref" value="" />
+			<enum name="apply_to_target_type" value="entity" />
+			<list name="apply_to_unit_classes">
+			</list>
+			<enum name="apply_to_application_type" value="current_and_future_units" />
+			<enum name="apply_to_future_units" value="current_and_future_units" />
+		</group>
+		<enum_table name="squad_cost">
+			<float name="action" value="0" />
+			<float name="command" value="0" />
+			<float name="popcap" value="0" />
+			<float name="food" value="0" />
+			<float name="wood" value="0" />
+			<float name="stone" value="0" />
+			<float name="gold" value="0" />
+			<float name="militia_hre" value="0" />
+		</enum_table>
+		<list name="float_properties">
+		</list>
+		<list name="int_properties">
+		</list>
+		<enum name="ui_group_cast_type" value="single" />
+	</group>
+	<uniqueid name="pbgid" value="134809" />
+	<instance_reference name="parent_pbg" value="" />
+</instance>

--- a/assets/attrib/instances/upgrade/races/mongol/research/upgrade_outpost_cannon_mon.xml
+++ b/assets/attrib/instances/upgrade/races/mongol/research/upgrade_outpost_cannon_mon.xml
@@ -1,0 +1,255 @@
+<instance description="Adds archers to the castle" template="upgrade">
+	<group name="upgrade_bag">
+		<bool name="enable_in_hold" value="False" />
+		<float name="global_max_limit" value="0" />
+		<bool name="has_speech_code" value="False" />
+		<float name="local_max_limit" value="1" />
+		<enum name="owner_type" value="self" />
+		<group name="time_cost">
+			<enum_table name="cost">
+				<float name="action" value="0" />
+				<float name="command" value="0" />
+				<float name="popcap" value="0" />
+				<float name="food" value="0" />
+				<float name="wood" value="0" />
+				<float name="stone" value="450" overrideParent="True" />
+				<float name="gold" value="150" overrideParent="True" />
+				<float name="militia_hre" value="0" />
+			</enum_table>
+			<float name="time_seconds" value="70" overrideParent="True" />
+		</group>
+		<bool name="ui_event_cue" value="True" />
+		<enum name="ui_production_group" value="command_panel" />
+		<group name="ui_info">
+			<locstring name="extra_text" value="11146084" />
+			<locstring name="help_text" value="0" />
+			<string name="hotkey_name" value="e" />
+			<file name="icon_name" value="races\common\upgrades\cannon" />
+			<bool name="reveal_for_decryption" value="False" />
+			<locstring name="screen_name" value="11146085" />
+			<locstring name="brief_text" value="0" />
+			<locstring name="screen_name_short" value="0" />
+			<string name="debug_text" value="" />
+			<string name="tooltip_data_template" value="BuildingUpgradeDataTemplate" />
+			<enum name="ui_combine_type" value="intersection" />
+			<template_reference name="brief_text_formatter" value="">
+			</template_reference>
+			<template_reference name="extra_text_formatter" value="">
+			</template_reference>
+			<template_reference name="help_text_formatter" value="ui_text_formatter">
+				<list name="formatter_arguments">
+				</list>
+				<locstring name="formatter" value="11220924" />
+			</template_reference>
+			<template_reference name="screen_name_formatter" value="">
+			</template_reference>
+			<template_reference name="screen_name_short_formatter" value="">
+			</template_reference>
+			<string name="sound" value="sfx_ui_produce_upgrade_building_click" />
+			<string name="sound_alternative" value="" />
+			<int name="global_unit_control_row" value="1" />
+		</group>
+		<list name="requirements">
+			<template_reference name="required" value="requirements\required_player_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="True" />
+				<int name="max_completed" value="100" />
+				<int name="min_completed" value="1" />
+				<instance_reference name="upgrade_name" value="upgrade\dev\ages\imperial_age" />
+				<bool name="include_queued" value="False" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\mongol\research\upgrade_outpost_arrowslits_mon" overrideParent="True" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\mongol\research\upgrade_outpost_arrowslits_mon" overrideParent="True" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\mongol\research\upgrade_outpost_springald_mon" overrideParent="True" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\mongol\research\upgrade_outpost_springald_mon" overrideParent="True" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\mongol\research\upgrade_outpost_cannon_mon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" overrideParent="True" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\mongol\research\upgrade_outpost_cannon_mon" mod="6f20ec44d3834818a4a2bc78bae3c5d9" overrideParent="True" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage_and_display" />
+				<locstring name="ui_name" value="11150626" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\chinese\research\upgrade_outpost_handcannonslits_chi" />
+				<bool name="include_queued" value="True" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+			<template_reference name="required" value="requirements\required_entity_upgrade">
+				<enum name="reason" value="usage" />
+				<locstring name="ui_name" value="0" />
+				<bool name="is_present" value="False" />
+				<instance_reference name="upgrade_name" value="upgrade\races\chinese\research\upgrade_outpost_handcannonslits_chi" />
+				<bool name="include_queued" value="False" />
+				<int name="min_completed" value="1" />
+				<int name="max_completed" value="100" />
+				<group name="include_pbg_parenting">
+					<bool name="include_child_pbgs" value="False" />
+					<bool name="include_parent_pbgs" value="False" />
+				</group>
+				<bool name="include_completed" value="True" />
+			</template_reference>
+		</list>
+		<file name="ui_kicker_icon_name" value="" />
+		<locstring name="ui_squad_name_override" value="0" />
+		<locstring name="ui_squad_help_text_override" value="0" />
+		<locstring name="ui_squad_extra_text_override" value="0" />
+		<list name="ui_preview">
+		</list>
+		<string name="speech_code" value="" />
+		<file name="ui_squad_portrait_icon_override" value="" />
+		<group name="ui_position">
+			<int name="ui_position_row" value="1" />
+			<int name="ui_position_column" value="3" />
+		</group>
+		<float name="min_music_intensity" value="0" />
+		<group name="state_tree_references">
+			<template_reference name="on_begin_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="upgrade_outpost\upgrade_outpost_cannon" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_cancel_action_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_entity_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+			<template_reference name="on_action_squad_tree" value="state_tree_reference_info">
+				<state_tree_node name="ActionTree_OpeningBranch" value="" />
+				<bool name="start_suspended" value="False" />
+			</template_reference>
+		</group>
+		<list name="upgrade_type">
+			<enum name="upgrade_type" value="military_upgrade" />
+		</list>
+		<string name="requirements_openingbranch" value="" />
+		<instance_reference name="ui_menu" value="" />
+		<bool name="is_progress_permanent" value="False" />
+		<group name="ui_codex_info">
+			<int name="priority" value="4700" />
+			<bool name="exclusive" value="False" />
+			<group name="ui_position">
+				<int name="ui_position_column" value="-1" />
+				<int name="ui_position_row" value="-1" />
+			</group>
+		</group>
+		<group name="filter_conditions">
+			<state_tree_node name="apply_to_filter_condition_statetree_ref" value="" />
+			<enum name="apply_to_target_type" value="entity" />
+			<list name="apply_to_unit_classes">
+			</list>
+			<enum name="apply_to_application_type" value="current_and_future_units" />
+			<enum name="apply_to_future_units" value="current_and_future_units" />
+		</group>
+		<enum_table name="squad_cost">
+			<float name="action" value="0" />
+			<float name="command" value="0" />
+			<float name="popcap" value="0" />
+			<float name="food" value="0" />
+			<float name="wood" value="0" />
+			<float name="stone" value="0" />
+			<float name="gold" value="0" />
+			<float name="militia_hre" value="0" />
+		</enum_table>
+		<list name="float_properties">
+		</list>
+		<list name="int_properties">
+		</list>
+		<enum name="ui_group_cast_type" value="single" />
+	</group>
+	<uniqueid name="pbgid" value="186400" />
+	<instance_reference name="parent_pbg" value="upgrade\races\common\research\upgrade_outpost_cannon" />
+</instance>


### PR DESCRIPTION
Increased cost of Tower, Keep and Outpost Cannon and Handcannon upgrades by 1.5* stone and 2* gold.
Increased time of Tower, Keep and Outpost Cannon upgrades from 60 to 70 seconds.
Increased cost of Wall Towers by 2* stone.
Increased time of Wall Towers by 30 seconds.
Increased cost of Keep from 800 stone to 1200 stone.
Increased time of Keep by 30 seconds.
Increased cost of Palisade walls from 5 wood to 8 wood.